### PR TITLE
Capitolo 4: rimosso banner "documento obsoleto"

### DIFF
--- a/cloud-enablement.rst
+++ b/cloud-enablement.rst
@@ -1,8 +1,6 @@
 Il Cloud Enablement
 -------------------
 
-.. include:: /banner.rst
-
 La situazione di elevata frammentazione e disomogeneità dei sistemi informativi
 delle PA necessita di un percorso evolutivo verso un utilizzo efficiente e
 flessibile delle tecnologie IT, al fine di garantire elevate economie gestionali


### PR DESCRIPTION
Questo capitolo è ancora valido, quindi rimuoviamo il banner "obsoleto".